### PR TITLE
add nftables set support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+        "editor.formatOnSave": false,
+        "files.trimTrailingWhitespace": false,
+        "[c]": {
+                "editor.semanticHighlighting.enabled": true
+        }
+}

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ regex_libs =    `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_REGEX $(PKG_CONFIG)
 nettle_cflags = `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_DNSSEC $(PKG_CONFIG) --cflags nettle hogweed`
 nettle_libs =   `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_DNSSEC $(PKG_CONFIG) --libs nettle hogweed`
 gmp_libs =      `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_DNSSEC NO_GMP --copy -lgmp`
+nf_libs =       `echo $(COPTS) | $(top)/bld/pkg-wrapper HAVE_NFSET $(PKG_CONFIG) --libs libnftables`
 sunos_libs =    `if uname | grep SunOS >/dev/null 2>&1; then echo -lsocket -lnsl -lposix4; fi`
 version =     -DVERSION='\"`$(top)/bld/get-version $(top)`\"'
 
@@ -79,7 +80,8 @@ objs = cache.o rfc1035.o util.o option.o forward.o network.o \
        helper.o tftp.o log.o conntrack.o dhcp6.o rfc3315.o \
        dhcp-common.o outpacket.o radv.o slaac.o auth.o ipset.o \
        domain.o dnssec.o blockdata.o tables.o loop.o inotify.o \
-       poll.o rrfilter.o edns0.o arp.o crypto.o dump.o ubus.o metrics.o
+       poll.o rrfilter.o edns0.o arp.o crypto.o dump.o ubus.o \
+       metrics.o nfset.o
 
 hdrs = dnsmasq.h config.h dhcp-protocol.h dhcp6-protocol.h \
        dns-protocol.h radv-protocol.h ip6addr.h metrics.h
@@ -88,7 +90,7 @@ all : $(BUILDDIR)
 	@cd $(BUILDDIR) && $(MAKE) \
  top="$(top)" \
  build_cflags="$(version) $(dbus_cflags) $(idn2_cflags) $(idn_cflags) $(ct_cflags) $(lua_cflags) $(regex_cflags) $(nettle_cflags)" \
- build_libs="$(dbus_libs) $(idn2_libs) $(idn_libs) $(ct_libs) $(lua_libs) $(sunos_libs) $(regex_libs) $(nettle_libs) $(gmp_libs) $(ubus_libs)" \
+ build_libs="$(dbus_libs) $(idn2_libs) $(idn_libs) $(ct_libs) $(lua_libs) $(sunos_libs) $(regex_libs) $(nettle_libs) $(gmp_libs) $(ubus_libs) $(nf_libs)" \
  -f $(top)/Makefile dnsmasq 
 
 mostly_clean :

--- a/dnsmasq.conf.example
+++ b/dnsmasq.conf.example
@@ -83,7 +83,14 @@
 
 # Add the IPs of all queries to yahoo.com, google.com, and their
 # subdomains to the vpn and search ipsets:
+# the same command can add nftable sets, if the set name starts 
+# with `ipv4 ` or `ipv6 ` it is treated as an nftable set, and 
+# not an iptable set.  Either way, its an IP Set.
+# nftable set names have the format: [ipv4/ipv6] <table type> <table name> <set name>
+# eg: ipv4 inet inet_table myset
+#   : ipv6 inet inet_table myset6 
 #ipset=/yahoo.com/google.com/vpn,search
+#ipset=/yahoo.com/google.com/ipv4 inet inet_table myset,ipv6 inet inet_table myset6
 
 # You can control how dnsmasq talks to a server: this forces
 # queries to 10.1.2.3 to be routed via eth1

--- a/src/config.h
+++ b/src/config.h
@@ -179,7 +179,8 @@ RESOLVFILE
 #define HAVE_TFTP
 #define HAVE_SCRIPT
 #define HAVE_AUTH
-#define HAVE_IPSET 
+// #define HAVE_IPSET 
+#define HAVE_NFSET
 #define HAVE_LOOP
 #define HAVE_DUMPFILE
 
@@ -436,6 +437,10 @@ static char *compile_opts =
 "no-"
 #endif
 "ipset "
+#ifndef HAVE_NFSET
+"no-"
+#endif
+"nfset "
 #ifndef HAVE_AUTH
 "no-"
 #endif

--- a/src/dnsmasq.c
+++ b/src/dnsmasq.c
@@ -317,10 +317,15 @@ int main (int argc, char **argv)
 
 #endif
 
-#ifdef HAVE_IPSET
+#if defined(HAVE_IPSET) || defined(HAVE_NFSET)
   if (daemon->ipsets)
     {
+#ifdef HAVE_IPSET      
       ipset_init();
+#endif
+#ifdef HAVE_NFSET
+      nfset_init();
+#endif
 #  ifdef HAVE_LINUX_NETWORK
       need_cap_net_admin = 1;
 #  endif

--- a/src/dnsmasq.h
+++ b/src/dnsmasq.h
@@ -1527,6 +1527,13 @@ void ipset_init(void);
 int add_to_ipset(const char *setname, const union all_addr *ipaddr, int flags, int remove, int ttl);
 #endif
 
+/* nfset.c */
+#ifdef HAVE_NFSET
+void nfset_init(void);
+int is_nfset(const char* setname);
+int add_to_nfset(const char *setname, const union all_addr *ipaddr, int flags, int remove, int ttl);
+#endif
+
 /* helper.c */
 #if defined(HAVE_SCRIPT)
 int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd);

--- a/src/forward.c
+++ b/src/forward.c
@@ -663,7 +663,7 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
   (void)do_bit;
   (void)bogusanswer;
 
-#ifdef HAVE_IPSET
+#if defined(HAVE_IPSET) || defined(HAVE_NFSET)
   if (daemon->ipsets && extract_request(header, n, daemon->namebuff, NULL))
     {
       /* Similar algorithm to search_servers. */

--- a/src/nfset.c
+++ b/src/nfset.c
@@ -1,0 +1,119 @@
+/* ipset.c is Copyright (c) 2013 Jason A. Donenfeld <Jason@zx2c4.com>. All
+   Rights Reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991, or
+   (at your option) version 3 dated 29 June, 2007.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "dnsmasq.h"
+
+#if defined(HAVE_NFSET) && defined(HAVE_LINUX_NETWORK)
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <linux/version.h>
+#include <nftables/libnftables.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+
+#define MAX_TTL 4 * 60 * 60
+#define MIN_TTL 30 * 60
+
+struct nft_ctx *ctx = NULL;
+
+const char nft_ipv4[] = "ipv4 ";
+const char nft_ipv6[] = "ipv6 ";
+const char nft_cmd_add[] = "add element %s { %s timeout %ds }";
+
+#define CMD_BUFFER_SIZE 4096
+char cmd_buffer[CMD_BUFFER_SIZE];
+
+char addr_buffer[ADDRSTRLEN + 1];
+
+
+
+static int start_with(const char *s, const char *prefix) {
+  return strncmp(prefix, s, strlen(prefix)) == 0;
+}
+
+void nfset_init() {
+  ctx = nft_ctx_new(NFT_CTX_DEFAULT);
+  if (ctx == NULL) exit(EXIT_FAILURE);
+
+  // Catch Command output and errors internally, don;t send to stdout or stderr
+  nft_ctx_buffer_output(ctx);
+  nft_ctx_buffer_error(ctx);
+}
+
+int is_nfset(const char* setname) {
+  return start_with(setname, nft_ipv4) || start_with(setname, nft_ipv6);
+}
+
+int add_to_nfset(const char *setname, const union all_addr *ipaddr,
+                 int flags, int remove, int ttl) {
+
+  (void)remove; // Unused
+
+  int sent = 0;
+  int rc = 0;
+  int priority = LOG_DEBUG;
+  const char *out = NULL;
+  const char *err = NULL;
+
+
+  // Bound ttl into this range.
+  ttl = ttl < MIN_TTL ? MIN_TTL : ttl;
+  ttl = ttl > MAX_TTL ? MAX_TTL : ttl;
+
+  if (flags & F_IPV4) {
+    if (start_with(setname, nft_ipv4)) {
+      const char *real_setname = setname + strlen(nft_ipv4);
+      inet_ntop(AF_INET, ipaddr, addr_buffer, ADDRSTRLEN);
+      snprintf(cmd_buffer, CMD_BUFFER_SIZE, nft_cmd_add, real_setname, addr_buffer, ttl);
+      rc = nft_run_cmd_from_buffer(ctx, cmd_buffer);
+      sent = 1;
+    }
+  } else if (flags & F_IPV6) {
+    if (start_with(setname, nft_ipv6)) {
+      const char *real_setname = setname + strlen(nft_ipv6);
+      inet_ntop(AF_INET6, ipaddr, addr_buffer, ADDRSTRLEN);
+      snprintf(cmd_buffer, CMD_BUFFER_SIZE, nft_cmd_add, real_setname, addr_buffer, ttl);
+      rc = nft_run_cmd_from_buffer(ctx, cmd_buffer);
+      sent = 1;
+    }
+  }
+
+  if (sent == 1) {
+    // Always get the command output and error, to clear it.
+    out = nft_ctx_get_output_buffer(ctx);
+    err = nft_ctx_get_error_buffer(ctx);
+
+    // If we got any command output, increase our debug log to Info so its obvious.
+    if (strlen(out)) {
+      priority = LOG_INFO;
+    }
+
+    // If we get a bad status of error message, increase to error, so its really really obvious.
+    if ((rc != 0) || (strlen(err))) {
+      priority = LOG_ERR;
+    }
+
+    my_syslog(priority, _("nft set update `%s` : %d : %s : %s"), cmd_buffer, rc, out, err);
+  }
+
+  return 0;
+}
+
+#endif

--- a/src/option.c
+++ b/src/option.c
@@ -507,7 +507,7 @@ static struct {
   { LOPT_AUTHSOA, ARG_ONE, "<serial>[,...]", gettext_noop("Set authoritative zone information"), NULL },
   { LOPT_AUTHSFS, ARG_DUP, "<NS>[,<NS>...]", gettext_noop("Secondary authoritative nameservers for forward domains"), NULL },
   { LOPT_AUTHPEER, ARG_DUP, "<ipaddr>[,<ipaddr>...]", gettext_noop("Peers which are allowed to do zone transfer"), NULL },
-  { LOPT_IPSET, ARG_DUP, "/<domain>[/<domain>...]/<ipset>...", gettext_noop("Specify ipsets to which matching domains should be added"), NULL },
+  { LOPT_IPSET, ARG_DUP, "/<domain>[/<domain>...]/<ipset or nfset>...", gettext_noop("Specify ipsets to which matching domains should be added"), NULL },
   { LOPT_SYNTH, ARG_DUP, "<domain>,<range>,[<prefix>]", gettext_noop("Specify a domain and address range for synthesised names"), NULL },
   { LOPT_SEC_VALID, OPT_DNSSEC_VALID, NULL, gettext_noop("Activate DNSSEC validation"), NULL },
   { LOPT_TRUST_ANCHOR, ARG_DUP, "<domain>,[<class>],...", gettext_noop("Specify trust anchor key digest."), NULL },
@@ -2755,8 +2755,8 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
       }
 
     case LOPT_IPSET: /* --ipset */
-#ifndef HAVE_IPSET
-      ret_err(_("recompile with HAVE_IPSET defined to enable ipset directives"));
+#if !defined(HAVE_IPSET) && !defined(HAVE_NFSET)
+      ret_err(_("recompile with HAVE_IPSET and/or HAVE_NFSET defined to enable ipset directives"));
       break;
 #else
       {


### PR DESCRIPTION
This is a cross port.  The original port was for v2.77 upstream introduced it in 2.87.
Due to a massive internal change our regex changes would need a re-write, so we can;t forward merge this version to upstream head.
The original version also had a lot of replicated code vs ipsets and would have lost all the regex changes when using nftables ip sets.  So, I retained the original nftables logic and defines, but made it use the ipset config.
It detects if iptables ip sets are used or nftable ip sets based on the name of the set.  
iptables sets always have a single name, nftable sets are always multi part and start with ipv4 or ipv6 to specify the kind of set.
This change then enables support for adding addresses to nftables ip sets while retaining all the regex changes made to iptables ip sets.